### PR TITLE
Removing requirements on built in packages

### DIFF
--- a/Quote.plug
+++ b/Quote.plug
@@ -3,7 +3,7 @@ Name = Quote
 Module = Quote
 
 [Python]
-Version = 2+
+Version = 2.5+
 
 [Documentation]
 Description = Simple sqlite based quote storage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-os
-sqlite3
-logging


### PR DESCRIPTION
The three libraries listed in requirements.txt are all integrated into the default python distribution as of 2.5, from what I'm able to deduce. This causes the plugin to fail to install, since these modules aren't part of the PyPI list. This PR removes them and updates the plugin Python requirement to 2.5+ which allows installation for me.
